### PR TITLE
[Fix] updated attributes access

### DIFF
--- a/app/routes/local/institution.py
+++ b/app/routes/local/institution.py
@@ -65,5 +65,5 @@ async def create_institution(institution: schemas_institution, db: Session = Dep
 async def all_institutions(db: Session = Depends(get_db)):
     institutions = LocalImpl(db).get_merge_institutions()
 
-    return [{"id": institution["id_inst"], "name": institution["name"], "portal": institution["portal"]}
+    return [{"id": institution.id, "name": institution.name}
             for institution in institutions]


### PR DESCRIPTION
## Descripción del cambio.
Se modificó la forma de acceder a los atributos en el endpoint `/allWithNewData`. Debido al cambio realizado en el método `get_merge_institutions()`, en el cuál se dejó de utilizar HSI como fuente para traer información acerca de las instituciones, fue necesario modificar el accesso a los atributos del objeto **Institutions**.

### Cambios realizados.

- Se actualizó el acceso a atributos en el endpoint `/allWithNewData`.
- Se reemplazó la notación de diccionario por la notación de punto.